### PR TITLE
Replacing deprecated load() event shortcut

### DIFF
--- a/app/scripts/viewmodel.js
+++ b/app/scripts/viewmodel.js
@@ -139,7 +139,7 @@ define(['knockout',
                 currentImageFilename('');
                 errorHandler.handleError('loading image failed');
             } else {
-                $image.attr('src', filename).load(function () {
+                $image.attr('src', filename).on("load", function () {
                     currentImageFilename(filename);
                     isMakingAjaxRequest(false);
                     $image.fadeTo('fast', 1.0);


### PR DESCRIPTION
It appears that `load()` now tries to make an [AJAX call](https://api.jquery.com/load/) instead of registering [an event](https://api.jquery.com/load-event/) - so the event was never triggering on image load. 